### PR TITLE
fixed env_windows.yaml file

### DIFF
--- a/env_windows.yaml
+++ b/env_windows.yaml
@@ -4,30 +4,28 @@ channels:
   - defaults
 dependencies:
   - blas=1.0=mkl
-  - bottleneck=1.3.5=py310ha9d4c09_0
-  - ca-certificates=2023.08.22=h06a4308_0
-  - intel-openmp=2023.1.0=hdb19cb5_46306
-  - libffi=3.4.4=h6a678d5_0
-  - mkl=2023.1.0=h213fc3f_46344
-  - mkl-service=2.4.0=py310h5eee18b_1
-  - mkl_fft=1.3.8=py310h5eee18b_0
-  - mkl_random=1.2.4=py310hdb19cb5_0
-  - ncurses=6.4=h6a678d5_0
-  - numexpr=2.8.7=py310h85018f9_0
-  - openssl=3.0.12=h7f8727e_0
-  - pip=23.3.1=py310h06a4308_0
-  - python=3.10.13=h955ad1f_0
-  - python-dateutil=2.8.2=pyhd3eb1b0_0
-  - python-tzdata=2023.3=pyhd3eb1b0_0
-  - pytz=2023.3.post1=py310h06a4308_0
-  - readline=8.2=h5eee18b_0
-  - six=1.16.0=pyhd3eb1b0_1
-  - sqlite=3.41.2=h5eee18b_0
-  - tk=8.6.12=h1ccaba5_0
-  - tzdata=2023c=h04d1e81_0
-  - wheel=0.41.2=py310h06a4308_0
-  - xz=5.4.5=h5eee18b_0
-  - zlib=1.2.13=h5eee18b_0
+  - bottleneck=1.3.5
+  - ca-certificates=2023.08.22
+  - intel-openmp=2023.1.0
+  - libffi=3.4.4
+  - mkl=2023.1.0
+  - mkl-service=2.4.0
+  - mkl_fft=1.3.8
+  - mkl_random=1.2.4
+  - numexpr=2.8.7
+  - openssl=3.0.12
+  - pip=23.3.1
+  - python=3.10.13
+  - python-dateutil=2.8.2
+  - python-tzdata=2023.3
+  - pytz=2023.3.post1
+  - six=1.16.0
+  - sqlite=3.41.2
+  - tk=8.6.12
+  - tzdata=2023c
+  - wheel=0.41.2
+  - xz=5.4.5
+  - zlib=1.2.13
   - pip:
       - absl-py==2.0.0
       - aiohttp==3.9.1


### PR DESCRIPTION
This PR updates the env_windows.yaml file by simplifying package version constraints and removing platform-specific build strings. The updated environment file resolves previous environment creation issues and ensures compatibility across systems.

Changes Made:
1. Removed build-specific suffixes (e.g., py310ha9d4c09_0) from conda dependencies to allow Conda to choose the appropriate build for the current system.
2. Retained exact package versions where necessary to ensure reproducibility.

Reason for Change:
The previous environment file was causing issues during environment creation due to overly strict version/build pinning, especially on systems where the exact builds were unavailable. This update improves portability and makes the environment easier to recreate.